### PR TITLE
Remove duplicate code

### DIFF
--- a/custom-hash-table.lisp
+++ b/custom-hash-table.lisp
@@ -28,12 +28,10 @@ the function MAKE-FOO-HT is defined."
             (defun ,make (&rest options)
               #+ecl (declare (ignore options))
               (checking-reader-conditionals
-               #+(or allegro ccl lispworks)
+               #+(or allegro ccl lispworks sbcl)
                (apply #'make-hash-table :test ',test :hash-function ',hash-function options)
                #+cmu 
                (apply #'make-hash-table :test ',hash-table-test-sym options)
-               #+sbcl
-               (apply #'make-hash-table :test ',test :hash-function ',hash-function options)
                #-(or allegro ccl cmu lispworks sbcl)
                (make-custom-hash-table :test ',test
                                        :hash-function ',hash-function


### PR DESCRIPTION
SBCL uses exactly the same form for creating the hash table as the others, no need to split it out separately.